### PR TITLE
Fixed screw hole

### DIFF
--- a/servo_arm.scad
+++ b/servo_arm.scad
@@ -195,7 +195,8 @@ module servo_arm(params, arms) {
             cylinder(r = head_diameter / 2 + head_thickness, h = head_height + 1);
         }
 
-        cylinder(r = head_screw_diameter / 2, h = 10);
+        translate([0, 0, 0.1])
+            cylinder(r = head_screw_diameter / 2, h = head_height + 1);
 
         servo_head(params);
     }


### PR DESCRIPTION
Previous code had the screw hole height hard-coded to 10mm. This fix utilizes the `head_height` variable to create a hole for any shaft height.